### PR TITLE
More flexible search specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ node_id				# node id
 Newegg.navigate(store_id, category_id, node_id) #=> Array<Newegg::Category>
 ```
 
-#### Search for Products
+#### Search for Products (all arguments optional)
 ```ruby
-Newegg.search(store_id, category_id, sub_category_id, node_id, page_number, sort = "FEATURED") #=> json
+Newegg.search(store_id: STORE_ID, category_id: CAT_ID, sub_category_id: SUB_CAT_ID, node_id: NODE_ID, page_number: 1, sort: "FEATURED", keywords: KEYWORDS) #=> json
 ```
 ```json
 {

--- a/lib/newegg/api.rb
+++ b/lib/newegg/api.rb
@@ -94,7 +94,7 @@ module Newegg
           'PageNumber'           => options[:page_number]
       }
 
-      JSON.parse(api_post("Search.egg", "Advanced", request).body)
+      JSON.parse(api_post("Search.egg", "Advanced", request).body, {quirks_mode: true})
     end
 
     #

--- a/lib/newegg/api.rb
+++ b/lib/newegg/api.rb
@@ -77,21 +77,21 @@ module Newegg
     # @param [String] keywords   
     #
     def search(options={})
-      options = {store_id: nil, category_id: nil, sub_category_id: nil, node_id: nil, page_number: 1, sort: "FEATURED",
+      options = {store_id: -1, category_id: -1, sub_category_id: -1, node_id: -1, page_number: 1, sort: "FEATURED",
                  keywords: ""}.merge(options)
       request = {
           'IsUPCCodeSearch'      => false,
-          'IsSubCategorySearch'  => true,
+          'IsSubCategorySearch'  => options[:sub_category_id] > 0,
           'isGuideAdvanceSearch' => false,
-          'StoreDepaId'          => options['store_id'],
-          'CategoryId'           => options['category_id'],
-          'SubCategoryId'        => options['sub_category_id'],
-          'NodeId'               => options['node_id'],
+          'StoreDepaId'          => options[:store_id],
+          'CategoryId'           => options[:category_id],
+          'SubCategoryId'        => options[:sub_category_id],
+          'NodeId'               => options[:node_id],
           'BrandId'              => -1,
           'NValue'               => "",
-          'Keyword'              => options['keywords'],
-          'Sort'                 => options['sort'],
-          'PageNumber'           => options['page_number']
+          'Keyword'              => options[:keywords],
+          'Sort'                 => options[:sort],
+          'PageNumber'           => options[:page_number]
       }
 
       JSON.parse(api_post("Search.egg", "Advanced", request).body)

--- a/lib/newegg/api.rb
+++ b/lib/newegg/api.rb
@@ -65,7 +65,7 @@ module Newegg
     end
     
     #
-    # retrieves a single page of products given a specific store_id, category_id, sub_category_id,
+    # retrieves a single page of products given a query specified by an options hash. See options below.
     # node_id, page_number, and an optional sorting method
     #
     # @param [Integer] store_id, from @api.navigation, returned as StoreID
@@ -73,27 +73,30 @@ module Newegg
     # @param [Integer] sub_category_id from @api.navigation, returned as CategoryID
     # @param [Integer] node_id from @api.navigation, returned as NodeId
     # @param [Integer] page_number of the paginated search results, returned as PaginationInfo from search
-    # @param [optional, String] sort style of the returned search results, default is FEATURED
+    # @param [String] sort style of the returned search results, default is FEATURED
+    # @param [String] keywords   
     #
-    def search(store_id, category_id, sub_category_id, node_id, page_number, sort = "FEATURED")
+    def search(options={})
+      options = {store_id: nil, category_id: nil, sub_category_id: nil, node_id: nil, page_number: 1, sort: "FEATURED",
+                 keywords: ""}.merge(options)
       request = {
           'IsUPCCodeSearch'      => false,
           'IsSubCategorySearch'  => true,
           'isGuideAdvanceSearch' => false,
-          'StoreDepaId'          => store_id,
-          'CategoryId'           => category_id,
-          'SubCategoryId'        => sub_category_id,
-          'NodeId'               => node_id,
+          'StoreDepaId'          => options['store_id'],
+          'CategoryId'           => options['category_id'],
+          'SubCategoryId'        => options['sub_category_id'],
+          'NodeId'               => options['node_id'],
           'BrandId'              => -1,
           'NValue'               => "",
-          'Keyword'              => "",
-          'Sort'                 => sort,
-          'PageNumber'           => page_number
+          'Keyword'              => options['keywords'],
+          'Sort'                 => options['sort'],
+          'PageNumber'           => options['page_number']
       }
 
       JSON.parse(api_post("Search.egg", "Advanced", request).body)
     end
-    
+
     #
     # retrieve product information given an item number
     #

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -44,16 +44,16 @@ describe Newegg::Api do
     @api.navigate(response["StoreID"], response["CategoryID"], response["NodeId"]).should_not be_nil
   end
 
-  it %q{returns success for retrieve(store_id, category_id, sub_category_id, node_id)} do
+  it %q{returns success for search(store_id, category_id, sub_category_id, node_id)} do
     response ={"Description" => "Computer Cases", "CategoryType" => 1, "CategoryID" => 7, "StoreID" => 1, "ShowSeeAllDeals" => false, "NodeId" => 7583}
-    @api.search(response["StoreID"], response["CategoryType"], response["CategoryID"], response["NodeId"], 1).should_not be_nil
+    @api.search(store_id: response["StoreID"], category_id: response["CategoryType"], sub_category_id: response["CategoryID"], node_id: response["NodeId"], page_number: 1).should_not be_nil
   end
 
   it %q{throws error for search(store_id, category_id, sub_category_id, node_id} do
     FakeWeb.register_uri(:post, %r{http://www.ows.newegg.com/Search.egg/Advanced}, :status => ["404", "Not Found"])
     response = {"Description" => "Computer Cases", "CategoryType" => 1, "CategoryID" => 7, "StoreID" => 1, "ShowSeeAllDeals" => false, "NodeId" => 7583}
     lambda {
-      @api.search(response["StoreID"], response["CategoryType"], response["CategoryID"], response["NodeId"], 1)
+      @api.search(store_id: response["StoreID"], category_id: response["CategoryType"], sub_category_id: response["CategoryID"], node_id: response["NodeId"], page_number: 1)
     }.should raise_error Newegg::NeweggClientError
   end
 
@@ -61,8 +61,12 @@ describe Newegg::Api do
     FakeWeb.register_uri(:post, %r{http://www.ows.newegg.com/Search.egg/Advanced}, :status => ["500", "Server"])
     response = {"Description" => "Computer Cases", "CategoryType" => 1, "CategoryID" => 7, "StoreID" => 1, "ShowSeeAllDeals" => false, "NodeId" => 7583}
     lambda {
-      @api.search(response["StoreID"], response["CategoryType"], response["CategoryID"], response["NodeId"], 1)
+      @api.search(store_id: response["StoreID"], category_id: response["CategoryType"], sub_category_id: response["CategoryID"], node_id: response["NodeId"], page_number: 1)
     }.should raise_error Newegg::NeweggServerError
+  end
+
+  it %q{returns success for search(keywords)} do
+    expect(@api.search(keywords: "gtx 770")).to_not be_nil
   end
 
   it %q{returns success for specifications} do

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -69,6 +69,10 @@ describe Newegg::Api do
     expect(@api.search(keywords: "gtx 770")['PaginationInfo']['TotalCount']).to be > 0
   end
 
+  it %q{returns nil for a NULL search result} do
+    expect(@api.search()).to be_nil
+  end
+
   it %q{returns success for specifications} do
     response = {"NeweggItemNumber" => "N82E16823201044", "Title" => "Rosewill Mechanical Keyboard RK-9000RE with Cherry MX Red Switch", "SpecificationGroupList" =>
             [{"GroupName" => "Model", "SpecificationPairList" => [{"Key" => "Brand", "Value" => "Rosewill"}, {"Key" => "Model", "Value" => "RK-9000RE"}]}, {"GroupName" => "Keyboard Connection Type", "SpecificationPairList" =>

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -75,7 +75,10 @@ describe Newegg::Api do
             [{"Key" => "Operating System Supported", "Value" => "Windows XP/ Vista/ 7/ 8"}, {"Key" => "System Requirement", "Value" => "1 x USB Port or PS/2 port"}]}, {"GroupName" => "Features", "SpecificationPairList" => [{"Key" => "Features", "Value" =>
             "Highly durable professional gaming keyboard\n\nExtremely responsive and accurate for hours of comfortable gaming\n\nGaming-grade lifetime: 50 million clicks\n\nDurable red metal inner chassis\n\nN-Key rollover: 104 Key could press at the same time, avoid any key jamming (Only PS2 mode, at USB Mode 6-key rollover)\n\nCherry Red Switches: linear feeling with light operating force, 50 million life cycle of the switch, comfortable typing for long term use, fast response on each key.\n\nLaser printing design for the keycap\n\nGold plated USB and PS/2 connector to ensure low latency\n\nHigh quality braided cable\n\nSpec for Cherry MX Red Switch: \nTotal Travel: 4.0-0.4 mm\nKey Stroke: 4.0+/-0.5 mm\nKey pitch: 19.05mm\nOperating Force: 2.0+/-0.5 oz\nLife Cycle: 50 x 10^6 Times"}]}, {"GroupName" => "Packaging", "SpecificationPairList" => [{"Key" => "Package Contents", "Value" => "Keyboard\nUser manual"}]}, {"GroupName" => "Manufacturer Warranty", "SpecificationPairList" => [{"Key" => "Parts", "Value" => "3 years limited"}, {"Key" => "Labor", "Value" => "1 year limited"}]}]}
 
-    @api.specifications("N82E16823201044").should eq(response)
+    specs = @api.specifications("N82E16823201044")
+    expect(specs['SpecificationGroupList'].length).to eq(response['SpecificationGroupList'].length)
+    res_group_names = response['SpecificationGroupList'].collect{|s| s['GroupName']}
+    specs['SpecificationGroupList'].each{|s| expect(res_group_names).to include s['GroupName']}
   end
 
 end #end Newegg::Api

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -46,7 +46,7 @@ describe Newegg::Api do
 
   it %q{returns success for search(store_id, category_id, sub_category_id, node_id)} do
     response ={"Description" => "Computer Cases", "CategoryType" => 1, "CategoryID" => 7, "StoreID" => 1, "ShowSeeAllDeals" => false, "NodeId" => 7583}
-    @api.search(store_id: response["StoreID"], category_id: response["CategoryType"], sub_category_id: response["CategoryID"], node_id: response["NodeId"], page_number: 1).should_not be_nil
+    @api.search(store_id: response["StoreID"], category_id: response["CategoryType"], sub_category_id: response["CategoryID"], node_id: response["NodeId"], page_number: 1)['PaginationInfo']['TotalCount'].should be > 0
   end
 
   it %q{throws error for search(store_id, category_id, sub_category_id, node_id} do
@@ -66,7 +66,7 @@ describe Newegg::Api do
   end
 
   it %q{returns success for search(keywords)} do
-    expect(@api.search(keywords: "gtx 770")).to_not be_nil
+    expect(@api.search(keywords: "gtx 770")['PaginationInfo']['TotalCount']).to be > 0
   end
 
   it %q{returns success for specifications} do


### PR DESCRIPTION
Changed API::search to take a hash of arguments. Newegg's API search endpoint is quite flexible in terms of what it   accepts as a valid query specification and it seems to me that there are times when it is valuable to not need to specify all of store_id, category_id, sub_category_id, and node_id. The most obvious of this is a simple keyword search; if all of the above are set to nil, but a Keyword is provided, Newegg has no trouble with the request, and this seems to be a useful use case to support. 

The proposed new signature for the search method and argument defaults:

``` ruby
def search(options={})
  options = {store_id: nil, category_id: nil, sub_category_id: nil, node_id: nil, page_number: 1, sort: "FEATURED",
    keywords: ""}.merge(options)
```
