### PR TITLE
Add to_h convience methods for Store and Category

### DIFF
--- a/lib/newegg/category.rb
+++ b/lib/newegg/category.rb
@@ -10,6 +10,17 @@ module Newegg
       self.show_see_all_deals = show_see_all_deals
       self.node_id = node_id
     end
-    
+
+    def to_h
+      @h ||= {
+          :description   => description,
+          :category_type => category_type,
+          :category_id   => category_id,
+          :store_id      => store_id,
+          :node_id       => node_id
+      }.freeze
+      @h
+    end
+
   end
 end

--- a/lib/newegg/store.rb
+++ b/lib/newegg/store.rb
@@ -10,5 +10,27 @@ module Newegg
       self.categories = []
     end
 
+    def get_categories(newegg = Newegg)
+      self.categories = newegg.categories(self.store_id).freeze if self.categories.empty?
+      self.categories
+    end
+
+    def to_h(newegg = Newegg)
+      unless @h
+        categories_hash = []
+        get_categories(newegg).each do |c|
+          categories_hash << c.to_h
+        end
+        @h = {
+          :title              => title,
+          :store_department   => store_department,
+          :store_id           => store_id,
+          :show_see_all_deals => show_see_all_deals,
+          :categories         => categories_hash
+        }.freeze
+      end
+      @h
+    end
+
   end
 end


### PR DESCRIPTION
With this PR, can get all Store info with categories with just

``` ruby
puts Newegg.stores.first.to_h
```

Or get just categories

``` ruby
puts Newegg.stores.first.get_categories
```
